### PR TITLE
updated aws-java-sdk to 1.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ license {
 dependencies {
     testCompile 'junit:junit:[4,)'
     testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'com.amazonaws:aws-java-sdk-s3:1.9.30'
+    testCompile 'com.amazonaws:aws-java-sdk-s3:1.10.1'
 }
 
 test {

--- a/src/main/resources/project/procedures/preamble.groovy
+++ b/src/main/resources/project/procedures/preamble.groovy
@@ -36,7 +36,7 @@ import groovyx.net.http.RESTClient
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
-@Grab('com.amazonaws:aws-java-sdk-s3:1.9.30')
+@Grab('com.amazonaws:aws-java-sdk-s3:1.10.1')
 @Grab(group = 'org.codehaus.groovy.modules.http-builder', module = 'http-builder', version = '0.7.1')
 
 enum RequestMethod {


### PR DESCRIPTION
updated aws-java-sdk from 1.9.30 to 1.10.1 to fix problem with java8u60
and above (https://github.com/aws/aws-sdk-java/issues/444)