### PR TITLE
bug fix- EC-S3 plugin upgrade shows invalid attached credentials

### DIFF
--- a/src/main/resources/project/ec_setup.pl
+++ b/src/main/resources/project/ec_setup.pl
@@ -124,8 +124,7 @@ my %WebsiteHosting = (
 if ($upgradeAction eq 'upgrade') {
     migrateConfigurations($otherPluginName);
     migrateProperties($otherPluginName);
-    debug "Migrated properties";
-    reattachExternalCredentials($otherPluginName);
+    reattachExternalConfigurations($otherPluginName);
 }
 
 


### PR DESCRIPTION
Bug fix for CDRO-608.
EC-S3 plugin upgrade shows invalid attached credentials.
When the plugin upgrade is made form 1.21 to 1.22 the existing configuration of the plugin gives `Error [InvalidCredentialName]`. This is the fix for this.